### PR TITLE
Fix for probably unintended behavior

### DIFF
--- a/src/Snap/StaticPages/Internal/Handlers.hs
+++ b/src/Snap/StaticPages/Internal/Handlers.hs
@@ -297,7 +297,7 @@ serveIndex soFar content = do
         let (noPosts,perEach) =
                 partition (\x -> X.tagName x == Just "no-posts") perEach'
 
-        let noPost = if null noPosts then [] else X.childNodes $ head noPosts
+        let noPost = concatMap X.childNodes noPosts
 
         let func post = runNodeListWith (postAttrs st post) perEach
         allNodes <-


### PR DESCRIPTION
I based some code I wrote on a function from this package, which I think does not work as intended, so I wrote a patch. A comment says it is going to ignore a no-posts tag, unless there are no posts, while I think it does not (haven't tried to run it).
While I at it, merging all no-posts tags to form the result seems like the most appropriate thing to do (instead of using the first one and ignoring the rest). As a bonus, it's simpler.
