### PR TITLE
Fix URL mapping for top level blog posts

### DIFF
--- a/src/Snap/StaticPages/Internal/Handlers.hs
+++ b/src/Snap/StaticPages/Internal/Handlers.hs
@@ -221,10 +221,6 @@ serveIndex soFar content = do
     let recent    =  take 5 rchron
 
     let runPosts = loopThru st
---    let splices1 = [ ("posts:alphabetical"        , runPosts alpha)
---                   , ("posts:chronological"       , runPosts chron)
---                   , ("posts:reverseChronological", runPosts rchron)
---                   , ("posts:recent"              , runPosts recent) ]
     let splices1 = do
         "posts:alphabetical"         ## runPosts alpha
         "posts:chronological"        ## runPosts chron

--- a/src/Snap/StaticPages/Internal/Post.hs
+++ b/src/Snap/StaticPages/Internal/Post.hs
@@ -308,7 +308,9 @@ buildContentMap baseURL basedir = build [] "."
             if ".md" `isSuffixOf` f then do
                 -- it's a post
                 let baseName = dropExtension f
-                let pId = concat [baseURL, "/", pathSoFar, "/", baseName]
+                let pId = if null pathSoFar
+                            then concat [baseURL, "/", baseName]
+                            else concat [baseURL, "/", pathSoFar, "/", baseName]
                 !p <- readPost pId fp
                 return $! Map.insert (B.pack baseName) (ContentPost p) mp
               else


### PR DESCRIPTION
If a blog post is found directly below the content folder, the
resulting URL contains a double slash.
Example: "content/mypost.md" gets mapped to "baseURL//mypost".
This commit fixes that behaviour.

Also removed left-over comments from previous commit.
