### PR TITLE
cabal boundary fix and compilation error fix

### DIFF
--- a/snap-static-pages.cabal
+++ b/snap-static-pages.cabal
@@ -23,8 +23,8 @@ Library
 
     ghc-options: -Wall -funbox-strict-fields -O2 -funfolding-use-threshold=16
     Build-Depends: base >= 4 && <5,
-                   aeson >= 0.6 && <0.9,
-                   attoparsec >= 0.10 && <0.13,
+                   aeson >= 0.6 && <0.12,
+                   attoparsec >= 0.10 && <0.14,
                    blaze-builder,
                    bytestring,
                    containers,

--- a/src/Snap/StaticPages/Internal/Time.hs
+++ b/src/Snap/StaticPages/Internal/Time.hs
@@ -3,7 +3,7 @@ module Snap.StaticPages.Internal.Time where
 import           Data.Time.Clock
 import           Data.Time.Format
 import           Data.Time.LocalTime
-import           System.Locale
+-- import           System.Locale
 import           Text.Printf
 
 


### PR DESCRIPTION
In cabal, aeson and attoparsec upper bounds updated.

Internal/Time.hs had defaultTimeLocale from two modules, thus commented System.Locale away. After these changes this package compiled with just 'cabal install'. However, was the method from time-package the right one?